### PR TITLE
Update hacs.json to render the README.md

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "Next Holiday Sensor",
-  "domains": ["sensor"]
+  "domains": ["sensor"],
+  "render_readme": true
 }


### PR DESCRIPTION
Added config in hacs to render the README.md instead of info.md in accordance with manifest spec here: https://hacs.xyz/docs/publish/start/#hacsjson